### PR TITLE
DLsite RJ code digit change fix  DLsite 更新が入り、RJコードの桁数が変わりました。 

### DIFF
--- a/DLSite_Product.py
+++ b/DLSite_Product.py
@@ -444,8 +444,10 @@ class DLSite_Product:
         resp = requests.request(method, url, headers=headers, params=params)
         if resp.ok and resp.content:
             return resp.content
+        elif resp.status_code == 404:
+            raise ValueError("DLsite 404 Product Not Found.")
         else:
-            raise ValueError
+            raise ValueError("get_content requests Error.")
 
     def get_product_rest(self, update: bool = False) -> dict:
         if not (self._product_rest) or update:

--- a/util.py
+++ b/util.py
@@ -1,7 +1,7 @@
 import re
 from typing import List, Tuple, Union
 
-REGEX_PREFIX = {"RJ": r"[Rr][Jj][0-9]{8}", "RG": r"[Rr][Gg][0-9]{5}"}
+REGEX_PREFIX = {"RJ": r"[Rr][Jj][0-9]{6,8}", "RG": r"[Rr][Gg][0-9]{5}"}
 
 
 def get_id_code(text: str, id_prefix: str) -> Union[str, None]:

--- a/util.py
+++ b/util.py
@@ -1,7 +1,7 @@
 import re
 from typing import List, Tuple, Union
 
-REGEX_PREFIX = {"RJ": r"[Rr][Jj][0-9]{6}", "RG": r"[Rr][Gg][0-9]{5}"}
+REGEX_PREFIX = {"RJ": r"[Rr][Jj][0-9]{8}", "RG": r"[Rr][Gg][0-9]{5}"}
 
 
 def get_id_code(text: str, id_prefix: str) -> Union[str, None]:


### PR DESCRIPTION
Hello, here is the fix for two points.

## 変更点
#### DLsiteが更新されRJコードの桁数が増えました。その対応
・6桁 → 8桁
#### 作品が存在しない場合とそれ以外のエラーを分けるため、404での返しを追加


## Changed
#### DLsite updated and the number of digits of the RJ code changed, so I changed it
・6 digits → 8 digits
#### Added If a 404 is returned, display it.
  
<br>
thanks.